### PR TITLE
Fix CompletionAction trigger

### DIFF
--- a/src/createFluidNavigator.js
+++ b/src/createFluidNavigator.js
@@ -42,10 +42,7 @@ export default (routeConfigMap, stackConfig = {}) => {
           onTransitionStart={this.props.onTransitionStart}
           onTransitionEnd={(transition, lastTransition) => {
             const { onTransitionEnd, navigation } = this.props;
-            if (
-              transition.navigation.state.isTransitioning &&
-              !lastTransition.navigation.state.isTransitioning
-            ) {
+            if (transition.navigation.state.isTransitioning) {
               navigation.dispatch(
                 StackActions.completeTransition({
                   key: navigation.state.key,


### PR DESCRIPTION
Fix CompleteAction trigger the same way it was fixed in StackNavigator in 

[#4115](https://github.com/react-navigation/react-navigation/pull/4115)

This fixes navigation event callbacks not being fired correctly when using fluid transitioner